### PR TITLE
collector backwards compatibility

### DIFF
--- a/lib/server_metrics/collector.rb
+++ b/lib/server_metrics/collector.rb
@@ -20,7 +20,7 @@ module ServerMetrics
       @options = options
       @data={}
       @memory={}
-      @collector_id = self.class.name+'-'+@options.to_a.sort_by { |a| a.first }.flatten.join('-')
+      @collector_id = self.class.name+'-'+@options.to_a.sort_by { |a| a.first.to_s }.flatten.join('-')
       @error=nil
     end
 


### PR DESCRIPTION
In ruby 1.8.7 sort_by method doesn't take symbol arguments, this PR fixes this.